### PR TITLE
Policy: Add git workflow safeguards to prevent direct main pushes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,17 +85,20 @@ cd backend
 
 **Manual Setup:**
 ```bash
-# 1. Start Supabase services
+# 1. Install git hooks for workflow safety
+./scripts/install-git-hooks.sh
+
+# 2. Start Supabase services
 cd backend
 supabase start
 
-# 2. CRITICAL: Serve Edge Functions with environment variables
+# 3. CRITICAL: Serve Edge Functions with environment variables
 supabase functions serve --env-file .env.local
 
-# 3. Start ngrok for device testing (in separate terminal)
+# 4. Start ngrok for device testing (in separate terminal)
 ngrok http 54321
 
-# 4. Seed test data (includes self person creation)
+# 5. Seed test data (includes self person creation)
 npm run seed:dev
 
 # If self person is missing, run the fix script
@@ -140,20 +143,25 @@ Self persons get unique conversation starters:
 
 ✅ **CORRECT Deployment Process:**
 ```bash
-# 1. Make changes to Edge Functions locally
-# 2. Test locally with local Supabase
+# 1. Create feature branch
+git checkout -b feature/your-feature-name
+
+# 2. Make changes to Edge Functions locally
+# 3. Test locally with local Supabase
 cd backend
 supabase functions serve --env-file .env.local
 
-# 3. Commit changes and create PR
+# 4. Commit changes to feature branch
 git add .
 git commit -m "Description of changes"
-git push origin feature-branch
 
-# 4. Create PR for review
+# 5. Push feature branch (NOT main)
+git push origin feature/your-feature-name
+
+# 6. Create PR for review
 gh pr create --title "Title" --body "Description"
 
-# 5. Merge PR - CI/CD automatically deploys to production
+# 7. Merge PR - CI/CD automatically deploys to production
 ```
 
 ❌ **FORBIDDEN Commands (DO NOT USE):**
@@ -270,8 +278,12 @@ supabase db reset --linked  # WILL DESTROY PRODUCTION DATA
 #### Edge Function Deployment Safety
 ✅ **Safe Process:**
 ```bash
-# Always use PR-based deployment
-git commit && git push && gh pr create
+# Always use feature branch workflow
+git checkout -b feature/your-change
+git add .
+git commit -m "Description"
+git push origin feature/your-change
+gh pr create
 # Wait for review and CI/CD deployment
 ```
 
@@ -449,10 +461,17 @@ struct Message: Codable, Identifiable {
 **Test Commands:**
 ```bash
 cd backend
+
+# Unit tests (when available)
 npm run test                # Run all tests
-npm run test:watch          # Run tests in watch mode  
+npm run test:watch          # Run tests in watch mode
 npm run test:coverage       # Run tests with coverage report
 npm run test:integration    # Run integration tests
+
+# Integration test scripts
+deno run --allow-net --allow-env scripts/test-person-creation.ts  # Test person API
+swift scripts/test-swift-decode.swift                              # Test Swift decoder
+./scripts/test-e2e-person-creation.sh                             # End-to-end person creation
 ```
 
 **Testing Requirements:**
@@ -541,13 +560,12 @@ xcodebuild test -project Mano.xcodeproj -scheme Mano -destination 'platform=iOS 
 **Test User**: `dev@mano.local` / `dev123456`
 **Mock APIs**: All external APIs (Anthropic, etc.) should be mocked in tests
 
-**Test Utilities Available:**
-- `createTestUser()` - Generate test user objects
-- `createTestPerson()` - Generate test person objects  
-- `createTestMessage()` - Generate test message objects
-- `makeTestRequest()` - Helper for HTTP endpoint testing
-- `assertValidPerson()` - Validate person object structure
-- `assertValidMessage()` - Validate message object structure
+**Test Scripts Available:**
+- `backend/scripts/test-person-creation.ts` - Test person creation API with started_working_together field
+- `backend/scripts/test-swift-decode.swift` - Test Swift custom decoder for date-only strings
+- `backend/scripts/test-e2e-person-creation.sh` - End-to-end test (backend + Swift + iOS build)
+- `backend/scripts/test-is-self.ts` - Test self-reflection person functionality
+- `backend/scripts/fix-self-person.ts` - Fix missing self persons for existing users
 
 ### CI/CD Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,41 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## 🚨 CRITICAL: Git Workflow Rules
+
+**NEVER commit or push directly to main!** Always use feature branches and pull requests.
+
+**MANDATORY Workflow:**
+1. **Create a feature branch** for ALL code changes
+2. **Commit to the feature branch**
+3. **Push the feature branch** to origin
+4. **Create a Pull Request** for review
+5. **Only merge via PR** after approval
+
+**Required Commands:**
+```bash
+# 1. Create and checkout feature branch
+git checkout -b feature/description-of-change
+
+# 2. Make changes and commit
+git add <files>
+git commit -m "Description"
+
+# 3. Push feature branch (NOT main)
+git push origin feature/description-of-change
+
+# 4. Create PR
+gh pr create --title "Title" --body "Description"
+```
+
+**FORBIDDEN Commands:**
+```bash
+git push origin main          # NEVER push directly to main
+git commit && git push        # NEVER push without creating a branch first
+```
+
+**Exception:** Only push to main if explicitly instructed by the user with confirmation.
+
 ## Project Overview
 
 **Mano** is an AI-powered companion application for people managers. This repository contains both:

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+echo "📦 Installing Git Hooks..."
+echo ""
+
+HOOK_DIR=".git/hooks"
+HOOK_FILE="$HOOK_DIR/pre-push"
+
+# Create pre-push hook
+cat > "$HOOK_FILE" << 'EOF'
+#!/bin/bash
+# Pre-push hook to prevent direct pushes to main branch
+
+protected_branch='main'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ "$current_branch" = "$protected_branch" ]; then
+    echo ""
+    echo "🚨 ERROR: Direct push to main branch is not allowed!"
+    echo ""
+    echo "Please use the proper workflow:"
+    echo "  1. Create a feature branch: git checkout -b feature/your-feature"
+    echo "  2. Push your feature branch: git push origin feature/your-feature"
+    echo "  3. Create a PR: gh pr create"
+    echo ""
+    echo "To bypass this check (only if explicitly approved):"
+    echo "  git push --no-verify origin main"
+    echo ""
+    exit 1
+fi
+
+exit 0
+EOF
+
+# Make hook executable
+chmod +x "$HOOK_FILE"
+
+echo "✅ Pre-push hook installed successfully!"
+echo ""
+echo "The hook will prevent direct pushes to main branch."
+echo "Use feature branches and PRs for all changes."
+echo ""


### PR DESCRIPTION
## Summary

Added mandatory git workflow rules and pre-push hook to prevent accidental direct pushes to main branch.

## Problem

I mistakenly pushed directly to main in the previous commit, bypassing the proper PR review process. This is unprofessional and bypasses important code review safeguards.

## Solution

**1. Updated CLAUDE.md:**
- Added prominent "Git Workflow Rules" section at the top
- Clear MANDATORY workflow steps (feature branch → commit → push → PR)
- Explicit FORBIDDEN commands list
- Only allows direct main push if user explicitly approves

**2. Created Pre-Push Git Hook:**
- `.git/hooks/pre-push` blocks any push to main branch
- Provides helpful error message with correct workflow
- Allows bypass with `--no-verify` flag for emergencies only

## Testing

Tested the hook - it successfully blocks pushes to main:
```
🚨 ERROR: Direct push to main branch is not allowed!

Please use the proper workflow:
  1. Create a feature branch: git checkout -b feature/your-feature
  2. Push your feature branch: git push origin feature/your-feature
  3. Create a PR: gh pr create
```

## Impact

This PR demonstrates the correct workflow and ensures I won't make this mistake again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)