### PR TITLE
Docs: Add PR deployment type labeling system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,37 @@ git commit && git push        # NEVER push without creating a branch first
 
 **Exception:** Only push to main if explicitly instructed by the user with confirmation.
 
+## 🏷️ CRITICAL: PR Deployment Labels
+
+**MANDATORY:** Every PR MUST include ONE deployment type badge at the very top of the description.
+
+### Deployment Types:
+
+**📱 App Only - Rebuild Required**
+- SwiftUI/iOS UI changes
+- App logic changes
+- **Jess needs to:** Rebuild app in Xcode (⇧⌘K then ⌘R)
+- **No backend deployment**
+
+**☁️ Backend Only - Auto-Deploy**
+- Edge Functions changes
+- Database migrations
+- API/backend logic
+- **Jess needs to:** Just merge - auto-deploys via CI/CD
+- **No app rebuild needed**
+
+**🔄 App + Backend - Both Required**
+- Full-stack features
+- Schema + UI changes
+- **Jess needs to:** Merge (backend auto-deploys) + rebuild app
+
+**📚 Docs/Config Only - No Action Required**
+- Documentation updates
+- Config/workflow files
+- **Jess needs to:** Just merge - nothing to deploy
+
+**Usage:** Copy the appropriate badge from `PR_TEMPLATE.md` into every PR description.
+
 ## Project Overview
 
 **Mano** is an AI-powered companion application for people managers. This repository contains both:

--- a/PR_TEMPLATE.md
+++ b/PR_TEMPLATE.md
@@ -1,0 +1,59 @@
+# PR Template
+
+<!-- DELETE THIS COMMENT BLOCK AFTER READING:
+Choose ONE deployment type badge below and delete the others.
+This tells the reviewer exactly what they need to do after merging.
+-->
+
+## 🚀 Deployment Type
+
+<!-- Keep only ONE of these badges: -->
+
+### 📱 **App Only** - Rebuild Required
+> **After merging:** Rebuild app in Xcode (⇧⌘K then ⌘R) to see changes on your device.
+> No backend deployment happens.
+
+<!-- OR -->
+
+### ☁️ **Backend Only** - Auto-Deploy
+> **After merging:** Changes automatically deploy to production via CI/CD.
+> No app rebuild needed - works immediately.
+
+<!-- OR -->
+
+### 🔄 **App + Backend** - Both Required
+> **After merging:**
+> 1. Backend auto-deploys to production
+> 2. Rebuild app in Xcode (⇧⌘K then ⌘R) to see changes
+
+<!-- OR -->
+
+### 📚 **Docs/Config Only** - No Action Required
+> **After merging:** No deployment or rebuild needed.
+> Documentation/configuration only.
+
+---
+
+## What's this?
+
+Brief description of what this PR does...
+
+## What changed
+
+- Change 1
+- Change 2
+- Change 3
+
+## Why this matters
+
+Explain the impact...
+
+## Testing
+
+- [ ] Tested locally
+- [ ] Build succeeds
+- [ ] Works as expected
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## 🚀 Deployment Type

### 📚 **Docs/Config Only** - No Action Required
> **After merging:** No deployment or rebuild needed.
> Documentation/configuration only.

---

## What's this?

Adds a PR template and workflow documentation to ensure every PR clearly indicates what deployment actions are required after merging.

## What changed

- **Created `PR_TEMPLATE.md`** with 4 deployment type badges:
  - 📱 **App Only** - Rebuild Required (SwiftUI/iOS changes)
  - ☁️ **Backend Only** - Auto-Deploy (Edge Functions, migrations, API)
  - 🔄 **App + Backend** - Both Required (full-stack features)
  - 📚 **Docs/Config Only** - No Action Required

- **Updated `CLAUDE.md`** with mandatory PR labeling rules:
  - Every PR must include ONE deployment type badge at the top
  - Explains what Jess needs to do for each type
  - Ensures clear communication about post-merge actions

## Why this matters

Eliminates confusion about what needs to happen after merging a PR. Jess will know instantly whether to:
- Just merge (backend auto-deploys)
- Merge + rebuild app in Xcode
- Merge + do both
- Just merge (no action needed)

## Testing

- [x] PR template created with clear deployment type options
- [x] CLAUDE.md updated with labeling requirements
- [x] Documentation is clear and actionable

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>