### PR TITLE
feat: Add account deletion and fix onboarding initial message

### DIFF
--- a/Mano/Services/SupabaseAuthManager.swift
+++ b/Mano/Services/SupabaseAuthManager.swift
@@ -145,4 +145,34 @@ class SupabaseAuthManager: ObservableObject {
             throw error
         }
     }
+
+    func deleteAccount() async throws {
+        isLoading = true
+        errorMessage = ""
+
+        defer {
+            isLoading = false
+        }
+
+        do {
+            // Verify user is authenticated
+            guard user != nil else {
+                throw NSError(domain: "AuthError", code: 0, userInfo: [NSLocalizedDescriptionKey: "No user logged in"])
+            }
+
+            // Call Edge Function to delete account (has service role permissions)
+            try await client.functions.invoke(
+                "delete-account",
+                options: .init(
+                    method: .delete
+                )
+            )
+
+            // Sign out after successful deletion
+            try await signOut()
+        } catch {
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
 }

--- a/Mano/Services/SupabaseClient.swift
+++ b/Mano/Services/SupabaseClient.swift
@@ -108,13 +108,17 @@ class SupabaseManager: ObservableObject {
     func signOut() async throws {
         try await auth.signOut()
     }
-    
+
+    func deleteAccount() async throws {
+        try await auth.deleteAccount()
+    }
+
     func fetchPeople() async throws -> [Person] {
         return try await people.fetchPeople()
     }
     
-    func createPerson(name: String, role: String?, relationshipType: String) async throws -> Person {
-        return try await people.createPerson(name: name, role: role, relationshipType: relationshipType)
+    func createPerson(name: String, role: String?, relationshipType: String, startedWorkingTogether: Date? = nil) async throws -> Person {
+        return try await people.createPerson(name: name, role: role, relationshipType: relationshipType, startedWorkingTogether: startedWorkingTogether)
     }
     
     func fetchMessages(for personId: UUID) async throws -> [Message] {

--- a/backend/supabase/functions/delete-account/index.ts
+++ b/backend/supabase/functions/delete-account/index.ts
@@ -1,0 +1,145 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+
+  // Only allow DELETE method
+  if (req.method !== 'DELETE') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      {
+        status: 405,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+
+  try {
+    // Create Supabase client with user's auth
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Authorization header is required' }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      )
+    }
+
+    // Create client with user's token to verify they're authenticated
+    const userClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      {
+        global: {
+          headers: { Authorization: authHeader },
+        },
+      }
+    )
+
+    // Get current user
+    const { data: { user }, error: userError } = await userClient.auth.getUser()
+    if (userError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication failed' }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      )
+    }
+
+    console.log(`🗑️ Deleting account for user: ${user.id}`)
+
+    // Create admin client with service role key
+    const adminClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    )
+
+    // Step 1: Delete storage files first (not cascade deleted automatically)
+    try {
+      const userFolder = `${user.id}`
+      console.log(`🗑️ Deleting storage files for user: ${userFolder}`)
+
+      // List all files in user's folder
+      const { data: files, error: listError } = await adminClient
+        .storage
+        .from('message-attachments')
+        .list(userFolder)
+
+      if (listError) {
+        console.warn('Warning: Could not list storage files:', listError)
+      } else if (files && files.length > 0) {
+        // Delete all files in user's folder
+        const filePaths = files.map(file => `${userFolder}/${file.name}`)
+        const { error: deleteFilesError } = await adminClient
+          .storage
+          .from('message-attachments')
+          .remove(filePaths)
+
+        if (deleteFilesError) {
+          console.warn('Warning: Could not delete some storage files:', deleteFilesError)
+        } else {
+          console.log(`✅ Deleted ${files.length} storage files`)
+        }
+      }
+    } catch (storageError) {
+      console.warn('Warning: Storage cleanup failed:', storageError)
+      // Continue with user deletion even if storage cleanup fails
+    }
+
+    // Step 2: Delete user using admin client
+    // This will cascade delete all related database data:
+    // - user_profiles (cascade)
+    // - people (cascade)
+    // - conversations (cascade via people)
+    // - messages (cascade)
+    // - message_files (cascade)
+    // - topics (cascade after migration)
+    // - conversation_embeddings (cascade)
+    // - conversation_summary_embeddings (cascade)
+    // - recurring_patterns (cascade)
+    // - cross_conversation_connections (cascade)
+    // - action_items (cascade)
+    const { error: deleteError } = await adminClient.auth.admin.deleteUser(user.id)
+
+    if (deleteError) {
+      console.error('Error deleting user:', deleteError)
+      throw deleteError
+    }
+
+    console.log(`✅ Successfully deleted account for user: ${user.id}`)
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Account successfully deleted'
+      }),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 200
+      }
+    )
+
+  } catch (error) {
+    console.error('Error in delete-account function:', error)
+    return new Response(
+      JSON.stringify({ error: (error as any).message }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+})

--- a/backend/supabase/migrations/20251005000001_fix_topics_cascade_delete.sql
+++ b/backend/supabase/migrations/20251005000001_fix_topics_cascade_delete.sql
@@ -1,0 +1,11 @@
+-- Fix topics table to cascade delete when user is deleted
+-- This ensures that when a user account is deleted, their topics are also removed
+
+ALTER TABLE topics
+DROP CONSTRAINT IF EXISTS topics_created_by_fkey;
+
+ALTER TABLE topics
+ADD CONSTRAINT topics_created_by_fkey
+FOREIGN KEY (created_by)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;

--- a/backend/supabase/migrations/20251005000002_fix_profile_completion_trigger.sql
+++ b/backend/supabase/migrations/20251005000002_fix_profile_completion_trigger.sql
@@ -1,0 +1,32 @@
+-- Fix profile completion trigger to work with user creation trigger
+-- The issue is that when handle_new_user() inserts into people,
+-- the profile completion trigger fires but can't find the function
+
+BEGIN;
+
+-- Drop existing trigger
+DROP TRIGGER IF EXISTS people_profile_completion_trigger ON people;
+
+-- Recreate trigger function with explicit schema references
+CREATE OR REPLACE FUNCTION update_profile_completion()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Use explicit schema reference and handle missing function gracefully
+  BEGIN
+    NEW.profile_completion_score := public.calculate_profile_completion_score(NEW);
+  EXCEPTION WHEN undefined_function THEN
+    -- If function doesn't exist yet, set to default
+    NEW.profile_completion_score := 0;
+  END;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp;
+
+-- Recreate trigger
+CREATE TRIGGER people_profile_completion_trigger
+  BEFORE INSERT OR UPDATE ON people
+  FOR EACH ROW
+  EXECUTE FUNCTION update_profile_completion();
+
+COMMIT;


### PR DESCRIPTION
## Summary
Implements complete account deletion with cascade cleanup and fixes is_self person initial message generation.

## Changes

### Delete Account Feature
- **Edge Function**: New `delete-account` function with service role permissions
  - Deletes all Storage files in user's folder
  - Cascades delete across all database tables
  - Proper error handling and logging
- **Database Migrations**:
  - Fixes `topics` table to cascade delete on user deletion
  - Fixes profile completion trigger blocking user creation
- **iOS Client**: 
  - Delete Account button in People List menu (temporary for testing)
  - Confirmation dialog with warning
  - Calls Edge Function with proper auth

### Onboarding Fix
- Fixed is_self person welcome message generation
- Now generates initial message when onboarding completes
- Uses user's auth token instead of anon key

## Cascade Delete Coverage

All user data is properly deleted:
- ✅ user_profiles
- ✅ people (+ conversations, connections, action items)
- ✅ messages (+ message_files)
- ✅ topics (now fixed!)
- ✅ conversation_embeddings
- ✅ conversation_summary_embeddings  
- ✅ recurring_patterns
- ✅ Storage files

## Testing
- ✅ Local testing confirmed cascade deletes work
- ✅ iOS build passes
- ✅ Edge Function deploys successfully

## Deployment
This will auto-deploy via CI/CD when merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)